### PR TITLE
Improve tech icons heading and style

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -35,12 +35,15 @@ const Header = () => {
       </div>
 
     <div className="tech-icons">
-        <div className="icon html"><img src={htmlIcon} alt="HTML" /></div>
-        <div className="icon html"><img src={cssIcon} alt="CSS" /></div>
-        <div className="icon js"><img src={jsIcon} alt="JavaScript" /></div>
-        <div className="icon react"><img src={reactIcon} alt="React" /></div>
-        <div className="icon node"><img src={nodeIcon} alt="Node.js" /></div>
-        <div className="icon figma"><img src={figmaIcon} alt="Figma" /></div>
+        <h3 className="tech-heading">This is the code I have best competence in.</h3>
+        <div className="icons-row">
+          <div className="icon html"><img src={htmlIcon} alt="HTML" /></div>
+          <div className="icon css"><img src={cssIcon} alt="CSS" /></div>
+          <div className="icon js"><img src={jsIcon} alt="JavaScript" /></div>
+          <div className="icon react"><img src={reactIcon} alt="React" /></div>
+          <div className="icon node"><img src={nodeIcon} alt="Node.js" /></div>
+          <div className="icon figma"><img src={figmaIcon} alt="Figma" /></div>
+        </div>
     </div>
     </header>
   );

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -80,15 +80,31 @@
 /* --- Tech icons --- */
 .tech-icons {
   display: flex;
-  justify-content: space-evenly;
+  flex-direction: column;
   align-items: center;
   background-color: #000;
   border-radius: 50px;
-  padding: 15px;
+  padding: 20px;
   width: 70%;
   max-width: 600px;
   margin: 20px auto;
+  gap: 15px;
+}
+
+.tech-heading {
+  color: #fff;
+  font-size: 20px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.icons-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   flex-wrap: wrap;
+  gap: 20px;
+  width: 100%;
 }
 
 .icon {
@@ -136,6 +152,15 @@
 
   .tech-icons {
     width: 90%;
+    padding: 15px;
+  }
+
+  .tech-heading {
+    font-size: 18px;
+  }
+
+  .icons-row {
+    gap: 15px;
   }
 }
 
@@ -180,5 +205,13 @@
 
   .tech-icons {
     padding: 10px;
+  }
+
+  .tech-heading {
+    font-size: 16px;
+  }
+
+  .icons-row {
+    gap: 12px;
   }
 }


### PR DESCRIPTION
## Summary
- add a heading inside the `tech-icons` section
- organize icons within a flex row
- enhance styling of `tech-icons` and make responsive adjustments

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683ff4af9dd8832f92278a11ec1a43ac